### PR TITLE
Support for _reindex

### DIFF
--- a/src/Contracts/ElasticsearchServiceContract.php
+++ b/src/Contracts/ElasticsearchServiceContract.php
@@ -25,6 +25,15 @@ interface ElasticsearchServiceContract
      */
     public function index(array $params = []);
 
+
+    /**
+     * @param array $params
+     *
+     * @return array
+     */
+    public function reindex(array $params = []);
+
+
     /**
      * @param array $params
      *

--- a/src/ElasticsearchService.php
+++ b/src/ElasticsearchService.php
@@ -49,6 +49,15 @@ class ElasticsearchService implements ElasticsearchServiceContract
     /**
      * @inheritdoc
      */
+    public function reindex(array $params = [])
+    {
+        return $this->client->reindex($params);
+    }
+
+
+    /**
+     * @inheritdoc
+     */
     public function bulk(array $params = [])
     {
         return $this->client->bulk($params);

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -20,7 +20,7 @@ class UnitTester extends \Codeception\Actor
 {
     use _generated\UnitTesterActions;
 
-   /**
-    * Define custom actions here
-    */
+    /**
+     * Define custom actions here
+     */
 }

--- a/tests/unit/ServiceTest.php
+++ b/tests/unit/ServiceTest.php
@@ -92,6 +92,46 @@ class ServiceTest extends \Codeception\TestCase\Test
         });
     }
 
+    /**
+     * Tests the reindex method.
+     */
+    public function testMethodReindex()
+    {
+        $input = [
+            'source' => [
+                'index' => 'my_src_index'
+            ],
+            'dest'   => [
+                'index' => 'my_dest_index'
+            ]
+        ];
+
+        $output = [
+            'took'                   => 3104,
+            'timed_out'              => false,
+            'total'                  => 270,
+            'updated'                => 0,
+            'created'                => 270,
+            'batches'                => 1,
+            'version_conflicts'      => 0,
+            'noops'                  => 0,
+            'retries'                => 0,
+            'throttled_millis'       => 0,
+            'requests_per_second'    => 'unlimited',
+            'throttled_until_millis' => 0,
+            'failures'               => []
+        ];
+
+        $this->client->expects($this->any())
+            ->method('reindex')
+            ->with($input)
+            ->will($this->returnValue($output));
+
+        $this->specify('method index is ran', function () use ($input, $output) {
+            verify($this->service->reindex($input))->equals($output);
+        });
+    }
+
 
     /**
      * Tests the bulk method.


### PR DESCRIPTION
Added support for [reindex](https://www.elastic.co/blog/reindex-is-coming)

From 
Changes proposed in this pull request:
 * Added `reindex` to `ElasticsearchServiceContract`
 * Added `reindex` to `ElasticsearchService`
 * Added simple test
