### PR TITLE
Initial Elasticsearch 5.x support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+composer.phar
 /vendor/
 /tests/_output/*
 /tests/_support/_generated/*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@
 
 Simple wrapper of [Elasticsearch-PHP](https://github.com/elastic/elasticsearch-php) for the [Lumen PHP framework](http://lumen.laravel.com/).
 
-**NOTE**: Branch 5.2 is using Lumen framework 5.2. Only bug fixes for 0.7.X should be tagged in the 5.2 branch.
+## Version support
+
+| Lumen | Elasticsearch | Library |
+|-------|---------------|---------|
+| 5.4.x | 5.x           | 2.x     |
+| 5.4.x | 2.x           | 1.x     |
+| 5.2.x | 2.x           | 0.7.x   |
 
 ## Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "elasticsearch/elasticsearch": "^2.1"
+        "elasticsearch/elasticsearch": "^5.3"
     },
     "require-dev": {
         "laravel/lumen-framework": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c5d9823be7be7e3f13d998dcb20b46a",
+    "content-hash": "f575e3c931b55ebad36a7fa764180d73",
     "packages": [
         {
             "name": "elasticsearch/elasticsearch",
-            "version": "v2.3.0",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elastic/elasticsearch-php.git",
-                "reference": "12a400656e4cf4c231d83cb56af3f50a27dcde93"
+                "reference": "50e5b1c63db68839b8acc1f4766769570a27a448"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/12a400656e4cf4c231d83cb56af3f50a27dcde93",
-                "reference": "12a400656e4cf4c231d83cb56af3f50a27dcde93",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/50e5b1c63db68839b8acc1f4766769570a27a448",
+                "reference": "50e5b1c63db68839b8acc1f4766769570a27a448",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/ringphp": "~1.0",
-                "php": ">=5.4",
+                "php": "^5.6|^7.0",
                 "psr/log": "~1.0"
             },
             "require-dev": {
                 "cpliakas/git-wrapper": "~1.0",
+                "doctrine/inflector": "^1.1",
                 "mockery/mockery": "0.9.4",
-                "phpunit/phpunit": "~4.7",
+                "phpunit/phpunit": "^4.7|^5.4",
                 "sami/sami": "~3.2",
-                "symfony/yaml": "2.4.3 as 2.4.2",
-                "twig/twig": "1.*"
+                "symfony/finder": "^2.8",
+                "symfony/yaml": "^2.8"
             },
             "suggest": {
                 "ext-curl": "*",
@@ -58,7 +59,7 @@
                 "elasticsearch",
                 "search"
             ],
-            "time": "2016-11-30T17:15:05+00:00"
+            "time": "2017-07-19T18:44:30+00:00"
         },
         {
             "name": "guzzlehttp/ringphp",
@@ -740,7 +741,6 @@
                 "rest",
                 "web service"
             ],
-            "abandoned": "guzzlehttp/guzzle",
             "time": "2014-01-28T22:29:15+00:00"
         },
         {


### PR DESCRIPTION
Closes #19

Changes proposed in this pull request:
 * Update the underlying `elasticsearch/elasticsearch` library to 5.x
 * Add a version matrix to the README

I went through the documentation regarding breaking changes for both Elasticsearch itself as well as the underlying library and it seems we're not using any features that have been deprecated. This is pretty much expected since this is mostly a query builder.
