### PR TITLE
Support add filters and aggregations

### DIFF
--- a/src/Search/Query/Compound/BoolQuery.php
+++ b/src/Search/Query/Compound/BoolQuery.php
@@ -73,6 +73,21 @@ class BoolQuery extends AbstractQuery
 
 
     /**
+     * @param array $filter
+     * @return BoolQuery
+     */
+    public function addFilters(array $filters)
+    {
+        foreach($filters as $filter) {
+            if ($filter instanceof QueryDSL) {
+                $this->addFilter($filter);
+            }
+        }
+        return $this;
+    }
+
+
+    /**
      * @param QueryDSL $query
      * @return BoolQuery
      */

--- a/src/Search/Query/Compound/BoolQuery.php
+++ b/src/Search/Query/Compound/BoolQuery.php
@@ -78,7 +78,7 @@ class BoolQuery extends AbstractQuery
      */
     public function addFilters(array $filters)
     {
-        foreach($filters as $filter) {
+        foreach ($filters as $filter) {
             if ($filter instanceof QueryDSL) {
                 $this->addFilter($filter);
             }

--- a/src/Search/Search.php
+++ b/src/Search/Search.php
@@ -157,6 +157,21 @@ class Search
 
 
     /**
+     * @param array $aggregations
+     * @return Search
+     */
+    public function addAggregations(array $aggregations)
+    {
+        foreach ($aggregations as $aggregation) {
+            if ($aggregation instanceof Aggregation) {
+                $this->addAggregation($aggregation);
+            }
+        }
+        return $this;
+    }
+
+
+    /**
      * @param int $page
      * @return Search
      */

--- a/tests/Search/Query/Compound/BoolQueryTest.php
+++ b/tests/Search/Query/Compound/BoolQueryTest.php
@@ -59,4 +59,47 @@ class BoolQueryTest extends AbstractQueryTestCase
 
         $this->assertEquals($expectedArray, $query->toArray());
     }
+
+    /**
+     * Test adding an array of filters to BoolQuery
+     */
+    public function testAddFilters()
+    {
+        $query = $this->queryBuilder->createBoolQuery();
+        $query->addMust($this->queryBuilder->createTermQuery()->setField('field1')->setValue('value1'));
+        $query->addFilter($this->queryBuilder->createTermQuery()->setField('field2')->setValue('value2'));
+
+        $filters = [
+            $this->queryBuilder->createTermsQuery()->setField('field3')->setValues(['value3']),
+            $this->queryBuilder->createTermsQuery()->setField('field4')->setValues(['value4']),
+        ];
+        $query->addFilters($filters);
+
+        $expectedArray = [
+            'bool' => [
+                'must'     => [
+                    [
+                        'term' => ['field1' => 'value1'],
+                    ],
+                ],
+                'filter'   => [
+                    [
+                        'term' => ['field2' => 'value2'],
+                    ],
+                    [
+                        'terms' => [
+                            'field3' => ['value3']
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            'field4' => ['value4']
+                        ],
+                    ]
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedArray, $query->toArray());
+    }
 }

--- a/tests/Search/SearchTest.php
+++ b/tests/Search/SearchTest.php
@@ -4,6 +4,7 @@ namespace Nord\Lumen\Elasticsearch\Tests\Search;
 
 use Nord\Lumen\Elasticsearch\Search\Aggregation\AggregationCollection;
 use Nord\Lumen\Elasticsearch\Search\Aggregation\Bucket\GlobalAggregation;
+use Nord\Lumen\Elasticsearch\Search\Aggregation\Bucket\TermsAggregation;
 use Nord\Lumen\Elasticsearch\Search\Query\Compound\BoolQuery;
 use Nord\Lumen\Elasticsearch\Search\Search;
 use Nord\Lumen\Elasticsearch\Search\Sort;
@@ -166,6 +167,43 @@ class SearchTest extends TestCase
                         'max_name' => ['max' => ['field' => 'field_name']],
                     ],
                 ],
+            ],
+            'size'  => 100,
+            'from'  => 0,
+        ], $this->search->buildBody());
+    }
+
+    /**
+     * Test adding an array of aggregation to Search
+     */
+    public function testAddAggregations()
+    {
+        $this->search = $this->service->createSearch();
+        $this->search->setPage(1);
+        $this->search->setSize(100);
+
+        $aggregations = [
+            (new TermsAggregation())->setName('name1')->setField('field1'),
+            (new TermsAggregation())->setName('name2')->setField('field2')
+        ];
+
+        $this->search->addAggregations($aggregations);
+
+        $this->assertInstanceOf(AggregationCollection::class, $this->search->getAggregations());
+
+        $this->assertEquals([
+            'query' => ['match_all' => []],
+            'aggs'  => [
+                'name1' => [
+                    'terms' => [
+                        'field' => 'field1'
+                    ]
+                ],
+                'name2' => [
+                    'terms' => [
+                        'field' => 'field2'
+                    ]
+                ]
             ],
             'size'  => 100,
             'from'  => 0,


### PR DESCRIPTION

Changes proposed in this pull request:
Added utility functions for adding array of filter to `BoolQuery` and array of aggregation to `Search`

Sample use cases:
```php
$this->createSearchQuery(['title','description'], $keyword)->addFilters($filters);
```

```php
 $this->createSearch($type)
                 ->setQuery($searchQuery)
                 ->addAggregations($aggregations)
                 ->setFrom($from)
                 ->setSize($size ?? $this->getDefaultSearchSize())
```