### PR TITLE
Fix "size" parameter handling during index migrations (closes #58)

### DIFF
--- a/src/Pipelines/Stages/CreateIndexStage.php
+++ b/src/Pipelines/Stages/CreateIndexStage.php
@@ -41,9 +41,9 @@ class CreateIndexStage implements StageInterface
         if ($this->elasticsearchService->indices()->exists(['index' => $payload->getIndexName()])) {
             $this->elasticsearchService->reindex([
                 'body' => [
-                    'size'   => $payload->getBatchSize(),
                     'source' => [
                         'index' => $payload->getIndexName(),
+                        'size'  => $payload->getBatchSize(),
                     ],
                     'dest'   => [
                         'index' => $payload->getTargetVersionName(),

--- a/tests/Pipelines/Stages/CreateIndexStageTest.php
+++ b/tests/Pipelines/Stages/CreateIndexStageTest.php
@@ -32,9 +32,9 @@ class CreateIndexStageTest extends TestCase
                       ->method('reindex')
                       ->with([
                           'body' => [
-                              'size'   => 100,
                               'source' => [
                                   'index' => 'foo',
+                                  'size'  => 100,
                               ],
                               'dest'   => [
                                   'index' => 'foo23',


### PR DESCRIPTION
Fixes #58 

Confirmed working:

```
array(14) {
  'took' =>
  int(76913)
  'timed_out' =>
  bool(false)
  'total' =>
  int(7980)
  'updated' =>
  int(0)
  'created' =>
  int(7980)
  'deleted' =>
  int(0)
  'batches' =>
  int(80)
  'version_conflicts' =>
  int(0)
  'noops' =>
  int(0)
  'retries' =>
  array(2) {
    'bulk' =>
    int(0)
    'search' =>
    int(0)
  }
  'throttled_millis' =>
  int(0)
  'requests_per_second' =>
  double(-1)
  'throttled_until_millis' =>
  int(0)
  'failures' =>
  array(0) {
  }
}
```

This was with a batch size of 100.