### PR TITLE
Fix memory issue with PHP

### DIFF
--- a/src/Documents/Bulk/BulkQuery.php
+++ b/src/Documents/Bulk/BulkQuery.php
@@ -57,7 +57,7 @@ class BulkQuery
      */
     public function isReady()
     {
-        return count($this->actions) === $this->bulkSize;
+        return count($this->actions) == $this->bulkSize;
     }
 
 


### PR DESCRIPTION

Fixes #64 

I investigated the php memory usage and found of that the `$builkQuery->toArray()` continuously consume more memory

```
echo "\n $i query size: " .strlen(serialize($bulkQuery->toArray())) / 1024 . 'kb';
```

```
0 query size: 615.474609375kb
 1 query size: 1196.4482421875kb
 2 query size: 1777.361328125kb
 3 query size: 2358.2333984375kb
 4 query size: 2942.728515625kb
 5 query size: 3523.8935546875kb
 6 query size: 4105.1845703125kb
 7 query size: 4684.66015625kb
 8 query size: 5297.61328125kb
 9 query size: 5913.3798828125kb
 10 query size: 6518.1962890625kb
 11 query size: 7125.005859375kb
 12 query size: 7702.3818359375kb
 13 query size: 8305.986328125kb
 14 query size: 8885.056640625kb
 15 query size: 9461.77734375kb
 16 query size: 10066.586914062kb
 17 query size: 10729.510742188kb
 18 query size: 11320.864257812kb
 19 query size: 11900.455078125kb
 20 query size: 12480.25390625kb
 21 query size: 13099.028320312kb
 22 query size: 13696.590820312kb
 23 query size: 14276.595703125kb
 24 query size: 14871.677734375kb
 25 query size: 15451kb
 26 query size: 16031.254882812kb
 27 query size: 16608.224609375kb
 28 query size: 17207.390625kb
 29 query size: 17789.02734375kb
 30 query size: 18366.375976562kb
 31 query size: 18943.423828125kb
 32 query size: 19548.782226562kb
````

It seems  `$bulkQuery->reset()` does not have any affect on memory releasing. After I create new `BulkQuery` for each `BulkAction` the memory usage drop significantly to amost equally same amount of memory.

```
 0 query size: 615.474609375kb
 1 query size: 580.99609375kb
 2 query size: 580.935546875kb
 3 query size: 580.89453125kb
 4 query size: 584.5166015625kb
 5 query size: 581.185546875kb
 6 query size: 581.3115234375kb
 7 query size: 579.49609375kb
 8 query size: 612.9736328125kb
 9 query size: 615.787109375kb
 10 query size: 604.8369140625kb
 11 query size: 606.830078125kb
 12 query size: 577.396484375kb
 13 query size: 603.625kb
 14 query size: 579.0908203125kb
 15 query size: 576.7412109375kb
 16 query size: 604.830078125kb
 17 query size: 662.9443359375kb
 18 query size: 591.3740234375kb
 19 query size: 579.611328125kb
 20 query size: 579.8193359375kb
 21 query size: 618.794921875kb
 22 query size: 597.5830078125kb
 23 query size: 580.025390625kb
 24 query size: 595.1025390625kb
 25 query size: 579.3427734375kb
 26 query size: 580.275390625kb
 27 query size: 576.990234375kb
 28 query size: 599.1865234375kb
 29 query size: 581.6572265625kb
 30 query size: 577.369140625kb
 31 query size: 577.068359375kb
 32 query size: 605.37890625kb
```

 