### PR TITLE
Print out response body from _reindex

### DIFF
--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -4,6 +4,8 @@ namespace Nord\Lumen\Elasticsearch\Console;
 
 use Illuminate\Console\Command;
 use Nord\Lumen\Elasticsearch\Contracts\ElasticsearchServiceContract;
+use Nord\Lumen\Elasticsearch\Helpers\ArrayHelper;
+use Symfony\Component\Console\Helper\Table;
 
 /**
  * Class AbstractCommand

--- a/src/Console/ApplyMigrationCommand.php
+++ b/src/Console/ApplyMigrationCommand.php
@@ -4,6 +4,7 @@ namespace Nord\Lumen\Elasticsearch\Console;
 
 use League\Pipeline\Pipeline;
 use Nord\Lumen\Elasticsearch\Exceptions\IndexExistsException;
+use Nord\Lumen\Elasticsearch\Helpers\ArrayHelper;
 use Nord\Lumen\Elasticsearch\Pipelines\Payloads\ApplyMigrationPayload;
 use Nord\Lumen\Elasticsearch\Pipelines\Stages\CheckIndexExistsStage;
 use Nord\Lumen\Elasticsearch\Pipelines\Stages\CreateIndexStage;
@@ -62,6 +63,8 @@ class ApplyMigrationCommand extends AbstractCommand
 
             $this->output->writeln(sprintf('Migrated %s to %s', $payload->getIndexName(),
                 $payload->getTargetVersionName()));
+
+            $this->output->table([], ArrayHelper::arrayToTableRows($payload->getReindexResponse()));
         } catch (IndexExistsException $e) {
             $this->output->writeln('No migration required');
         }

--- a/src/Console/ApplyMigrationCommand.php
+++ b/src/Console/ApplyMigrationCommand.php
@@ -64,7 +64,7 @@ class ApplyMigrationCommand extends AbstractCommand
             $this->output->writeln(sprintf('Migrated %s to %s', $payload->getIndexName(),
                 $payload->getTargetVersionName()));
 
-            $this->output->table([], ArrayHelper::arrayToTableRows($payload->getReindexResponse()));
+            $this->output->table([], ArrayHelper::toTableRowsInput($payload->getReindexResponse()));
         } catch (IndexExistsException $e) {
             $this->output->writeln('No migration required');
         }

--- a/src/Helpers/ArrayHelper.php
+++ b/src/Helpers/ArrayHelper.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Nord\Lumen\Elasticsearch\Helpers;
+
+/**
+ * Class ReindexResponseTransformer
+ * @package Nord\Lumen\Elasticsearch\Helpers
+ */
+class ArrayHelper
+{
+    /**
+     * Transform response array to Symfony Table rows input
+     * @param array $response
+     *
+     * @return array
+     */
+    public static function arrayToTableRows(array $response)
+    {
+        $rows = [];
+        foreach ($response as $key => $value) {
+            if(!is_array($value)) {
+                $rows[] = [$key, $value];
+            } else {
+                $rows[] = [$key, implode(",", $value)];
+            }
+        }
+        return $rows;
+    }
+}

--- a/src/Helpers/ArrayHelper.php
+++ b/src/Helpers/ArrayHelper.php
@@ -9,19 +9,21 @@ namespace Nord\Lumen\Elasticsearch\Helpers;
 class ArrayHelper
 {
     /**
-     * Transform response array to Symfony Table rows input
+     * Transform response array to symfony table rows input
      * @param array $response
      *
      * @return array
      */
-    public static function arrayToTableRows(array $response)
+    public static function toTableRowsInput(array $response)
     {
         $rows = [];
         foreach ($response as $key => $value) {
-            if(!is_array($value)) {
-                $rows[] = [$key, $value];
+            if (is_array($value)) {
+                $rows[] = [$key, count($value) ? http_build_query($value, '', ',') : '[]'];
+            } elseif (is_bool($value)) {
+                $rows[] = [$key, $value ? 'true' : 'false'];
             } else {
-                $rows[] = [$key, implode(",", $value)];
+                $rows[] = [$key, strval($value)];
             }
         }
         return $rows;

--- a/src/Pipelines/Payloads/ApplyMigrationPayload.php
+++ b/src/Pipelines/Payloads/ApplyMigrationPayload.php
@@ -25,6 +25,11 @@ class ApplyMigrationPayload extends MigrationPayload
     private $numberOfReplicas;
 
     /**
+     * @var array
+     */
+    private $reindexResponse;
+
+    /**
      * ApplyMigrationPayload constructor.
      *
      * @param string $configurationPath
@@ -91,5 +96,21 @@ class ApplyMigrationPayload extends MigrationPayload
     public function setNumberOfReplicas($numberOfReplicas)
     {
         $this->numberOfReplicas = $numberOfReplicas;
+    }
+
+    /**
+     * @return array
+     */
+    public function getReindexResponse()
+    {
+        return $this->reindexResponse;
+    }
+
+    /**
+     * @param array $reindexResponse
+     */
+    public function setReindexResponse(array $reindexResponse)
+    {
+        $this->reindexResponse = $reindexResponse;
     }
 }

--- a/src/Pipelines/Stages/ReIndexStage.php
+++ b/src/Pipelines/Stages/ReIndexStage.php
@@ -43,7 +43,7 @@ class ReIndexStage implements StageInterface
                 ],
             ]);
 
-            $this->elasticsearchService->reindex([
+            $response = $this->elasticsearchService->reindex([
                 'body' => [
                     'source' => [
                         'index' => $payload->getIndexName(),
@@ -54,6 +54,8 @@ class ReIndexStage implements StageInterface
                     ],
                 ],
             ]);
+
+            $payload->setReindexResponse($response);
         }
 
         return $payload;

--- a/tests/Helpers/ArrayHelperTest.php
+++ b/tests/Helpers/ArrayHelperTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Nord\Lumen\Elasticsearch\Tests\Helpers;
+
+use Nord\Lumen\Elasticsearch\Helpers\ArrayHelper;
+use Nord\Lumen\Elasticsearch\Tests\TestCase;
+
+/**
+ * Class ArrayHelperTest
+ * @package Nord\Lumen\Elasticsearch\Tests\Helpers
+ */
+class ArrayHelperTest extends TestCase
+{
+    public function testToTableRowsInput()
+    {
+        $raw = [
+            'took'     => 1,
+            'time_out' => false,
+            'created'  => 120,
+            'failures' => [],
+            'retries'  => [
+                'bulk'   => 0,
+                'search' => 0,
+            ]
+        ];
+
+        $rows = ArrayHelper::toTableRowsInput($raw);
+
+        $expected = [
+            ['took', 1],
+            ['time_out', 'false'],
+            ['created', 120],
+            ['failures', '[]'],
+            ['retries', 'bulk=0,search=0']
+        ];
+
+        $this->assertEquals($rows, $expected);
+    }
+}

--- a/tests/Pipelines/Stages/DummyPayload.php
+++ b/tests/Pipelines/Stages/DummyPayload.php
@@ -42,4 +42,9 @@ class DummyPayload extends ApplyMigrationPayload
     {
         return 'foo';
     }
+
+    public function getReindexResponse()
+    {
+        return [];
+    }
 }

--- a/tests/Pipelines/Stages/ReIndexStageTest.php
+++ b/tests/Pipelines/Stages/ReIndexStageTest.php
@@ -40,7 +40,7 @@ class ReIndexStageTest extends AbstractStageTestCase
                                   'index' => 'foo23',
                               ],
                           ],
-                      ]);
+                      ])->willReturn([]);
 
         $stage = new ReIndexStage($searchService);
         $stage(new DummyPayload());


### PR DESCRIPTION
This is my proposal for #60. Not sure if this is what we want but let's see.

Changes proposed in this pull request:
 *  Print out response from `_reindex` command in table format. For example

```
 ------------------------ ----------------- 
  took                     3                
  timed_out                false            
  total                    0                
  updated                  0                
  created                  0                
  deleted                  0                
  batches                  0                
  version_conflicts        0                
  noops                    0                
  retries                  bulk=0,search=0  
  throttled_millis         0                
  requests_per_second      -1               
  throttled_until_millis   0                
  failures                 []               
 ------------------------ ----------------- 
```

Original response may looks like this 

```
{
  "took" : 147,
  "timed_out": false,
  "created": 120,
  "updated": 0,
  "deleted": 0,
  "batches": 1,
  "version_conflicts": 0,
  "noops": 0,
  "retries": {
    "bulk": 0,
    "search": 0
  },
  "throttled_millis": 0,
  "requests_per_second": -1.0,
  "throttled_until_millis": 0,
  "total": 120,
  "failures" : [ ]
}
```