### PR TITLE
Added support for deleteByQuery

### DIFF
--- a/src/Contracts/ElasticsearchServiceContract.php
+++ b/src/Contracts/ElasticsearchServiceContract.php
@@ -63,6 +63,14 @@ interface ElasticsearchServiceContract
      *
      * @return array
      */
+    public function deleteByQuery(array $params = []);
+
+
+    /**
+     * @param array $params
+     *
+     * @return array
+     */
     public function create(array $params = []);
 
 

--- a/src/ElasticsearchService.php
+++ b/src/ElasticsearchService.php
@@ -85,6 +85,15 @@ class ElasticsearchService implements ElasticsearchServiceContract
     /**
      * @inheritdoc
      */
+    public function deleteByQuery(array $params = [])
+    {
+        return $this->client->deleteByQuery($params);
+    }
+
+
+    /**
+     * @inheritdoc
+     */
     public function create(array $params = [])
     {
         return $this->client->create($params);

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -199,6 +199,33 @@ class ServiceTest extends TestCase
     }
 
     /**
+     * Tests the delete by query method.
+     */
+    public function testMethodDeleteByQuery()
+    {
+        $input = [
+            'index' => 'my_index',
+            'type'  => 'my_type',
+            'id'    => 'my_id',
+        ];
+
+        $output = [
+            'found'    => 1,
+            '_index'   => 'my_index',
+            '_type'    => 'my_type',
+            '_id'      => 'my_id',
+            '_version' => 2,
+        ];
+
+        $this->client->expects($this->any())
+                     ->method('deleteByQuery')
+                     ->with($input)
+                     ->will($this->returnValue($output));
+
+        $this->assertEquals($output, $this->service->deleteByQuery($input));
+    }
+
+    /**
      * Tests the create method.
      */
     public function testMethodCreate()


### PR DESCRIPTION
Support for `deleteByQuery`. It is very handy when we want to delete all related index. 

For example:

```php
$this->getSearchService()->deleteByQuery([
    'index' => 'content',
    'type'  => 'post',
    'query' => [
        'term' => [
            'blog.id' => 'xxxx'
        ]
   ]
]);
```