### PR TITLE
Make re-index asynchronous to prevent timeouts

### DIFF
--- a/src/Contracts/ElasticsearchServiceContract.php
+++ b/src/Contracts/ElasticsearchServiceContract.php
@@ -1,6 +1,7 @@
 <?php namespace Nord\Lumen\Elasticsearch\Contracts;
 
 use Elasticsearch\Namespaces\IndicesNamespace;
+use Elasticsearch\Namespaces\TasksNamespace;
 use Nord\Lumen\Elasticsearch\Parsers\SortStringParser;
 use Nord\Lumen\Elasticsearch\Search\Aggregation\AggregationBuilder;
 use Nord\Lumen\Elasticsearch\Search\Query\QueryBuilder;
@@ -80,6 +81,12 @@ interface ElasticsearchServiceContract
      * @return array|bool
      */
     public function exists(array $params = []);
+
+
+    /**
+     * @return TasksNamespace
+     */
+    public function tasks();
 
 
     /**

--- a/src/ElasticsearchService.php
+++ b/src/ElasticsearchService.php
@@ -94,6 +94,15 @@ class ElasticsearchService implements ElasticsearchServiceContract
     /**
      * @inheritdoc
      */
+    public function tasks()
+    {
+        return $this->client->tasks();
+    }
+
+
+    /**
+     * @inheritdoc
+     */
     public function create(array $params = [])
     {
         return $this->client->create($params);

--- a/src/Pipelines/Stages/ReIndexStage.php
+++ b/src/Pipelines/Stages/ReIndexStage.php
@@ -45,7 +45,7 @@ class ReIndexStage implements StageInterface
 
             $task = $this->elasticsearchService->reindex([
                 'wait_for_completion' => false,
-                'body' => [
+                'body'                => [
                     'source' => [
                         'index' => $payload->getIndexName(),
                         'size'  => $payload->getBatchSize(),
@@ -56,17 +56,13 @@ class ReIndexStage implements StageInterface
                 ],
             ]);
 
-           for(;;) {
-               $response = $this->elasticsearchService->tasks()->get([
-                   'task_id' => $task['task']
-               ]);
+            do {
+                $response = $this->elasticsearchService->tasks()->get([
+                    'task_id' => $task['task']
+                ]);
 
-               if (boolval($response['completed']) === true) {
-                   break;
-               }
-
-               sleep(3);
-           }
+                sleep(1);
+            } while ((bool)$response['completed'] === false);
         }
 
         return $payload;

--- a/src/Pipelines/Stages/ReIndexStage.php
+++ b/src/Pipelines/Stages/ReIndexStage.php
@@ -43,7 +43,8 @@ class ReIndexStage implements StageInterface
                 ],
             ]);
 
-            $this->elasticsearchService->reindex([
+            $task = $this->elasticsearchService->reindex([
+                'wait_for_completion' => false,
                 'body' => [
                     'source' => [
                         'index' => $payload->getIndexName(),
@@ -54,6 +55,18 @@ class ReIndexStage implements StageInterface
                     ],
                 ],
             ]);
+
+           for(;;) {
+               $response = $this->elasticsearchService->tasks()->get([
+                   'task_id' => $task['task']
+               ]);
+
+               if (boolval($response['completed']) === true) {
+                   break;
+               }
+
+               sleep(3);
+           }
         }
 
         return $payload;

--- a/tests/Pipelines/Stages/AbstractStageTestCase.php
+++ b/tests/Pipelines/Stages/AbstractStageTestCase.php
@@ -3,6 +3,7 @@
 namespace Nord\Lumen\Elasticsearch\Tests\Pipelines\Stages;
 
 use Elasticsearch\Namespaces\IndicesNamespace;
+use Elasticsearch\Namespaces\TasksNamespace;
 use Nord\Lumen\Elasticsearch\Contracts\ElasticsearchServiceContract;
 use Nord\Lumen\Elasticsearch\Tests\TestCase;
 
@@ -21,6 +22,20 @@ abstract class AbstractStageTestCase extends TestCase
     protected function getMockedIndices($methods = [])
     {
         return $this->getMockBuilder(IndicesNamespace::class)
+                    ->disableOriginalConstructor()
+                    ->setMethods($methods)
+                    ->getMock();
+    }
+
+
+    /**
+     * @param array $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockedTasks($methods = [])
+    {
+        return $this->getMockBuilder(TasksNamespace::class)
                     ->disableOriginalConstructor()
                     ->setMethods($methods)
                     ->getMock();

--- a/tests/Pipelines/Stages/ReIndexStageTest.php
+++ b/tests/Pipelines/Stages/ReIndexStageTest.php
@@ -17,7 +17,18 @@ class ReIndexStageTest extends AbstractStageTestCase
     public function testWhenIndexExists()
     {
         $indices       = $this->getMockedIndices(['exists', 'putSettings']);
+        $tasks         = $this->getMockedTasks(['get']);
         $searchService = $this->getMockedSearchService($indices);
+
+
+        $tasks->expects($this->once())
+              ->method('get')
+              ->willReturn(['completed' => true]);
+
+        $searchService
+            ->expects($this->once())
+            ->method('tasks')
+            ->willReturn($tasks);
 
         $indices->expects($this->once())
                 ->method('exists')
@@ -31,6 +42,7 @@ class ReIndexStageTest extends AbstractStageTestCase
         $searchService->expects($this->once())
                       ->method('reindex')
                       ->with([
+                          'wait_for_completion' => false,
                           'body' => [
                               'source' => [
                                   'index' => 'foo',

--- a/tests/Pipelines/Stages/ReIndexStageTest.php
+++ b/tests/Pipelines/Stages/ReIndexStageTest.php
@@ -21,12 +21,15 @@ class ReIndexStageTest extends AbstractStageTestCase
         $searchService = $this->getMockedSearchService($indices);
 
 
-        $tasks->expects($this->once())
+        $tasks->expects($this->exactly(2))
               ->method('get')
-              ->willReturn(['completed' => true]);
+              ->willReturn(
+                  ['completed' => false],
+                  ['completed' => true]
+              );
 
         $searchService
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('tasks')
             ->willReturn($tasks);
 


### PR DESCRIPTION
- Added support for Tasks APIs
- Change ReindexStage, set `wait_for_completion=false`
