### PR TITLE
Add option to force update_all_types when doing migration

### DIFF
--- a/src/Console/ApplyMigrationCommand.php
+++ b/src/Console/ApplyMigrationCommand.php
@@ -25,7 +25,8 @@ class ApplyMigrationCommand extends AbstractCommand
      */
     protected $signature = 'elastic:migrations:migrate 
                             { config : The path to the index configuration file } 
-                            { --batchSize= : The number of documents to handle per batch while re-indexing }';
+                            { --batchSize= : The number of documents to handle per batch while re-indexing }
+                            { --updateAllTypes : Forces update across all types }';
 
     /**
      * The console command description.
@@ -40,11 +41,8 @@ class ApplyMigrationCommand extends AbstractCommand
     public function handle()
     {
         $configurationPath = (string)$this->argument('config');
-        $batchSize         = (int)$this->option('batchSize');
-
-        if ($batchSize === 0) {
-            $batchSize = self::DEFAULT_BATCH_SIZE;
-        }
+        $batchSize         = (int)$this->option('batchSize', self::DEFAULT_BATCH_SIZE);
+        $updateAllTypes    = (bool)$this->option('updateAllTypes', false);
 
         $pipeline = new Pipeline([
             new DetermineTargetVersionStage(),
@@ -55,7 +53,7 @@ class ApplyMigrationCommand extends AbstractCommand
             new UpdateIndexAliasStage($this->elasticsearchService),
         ]);
 
-        $payload = new ApplyMigrationPayload($configurationPath, $batchSize);
+        $payload = new ApplyMigrationPayload($configurationPath, $batchSize, $updateAllTypes);
 
         try {
             $pipeline->process($payload);

--- a/src/Pipelines/Payloads/ApplyMigrationPayload.php
+++ b/src/Pipelines/Payloads/ApplyMigrationPayload.php
@@ -20,6 +20,11 @@ class ApplyMigrationPayload extends MigrationPayload
     private $batchSize;
 
     /**
+     * @var bool
+     */
+    private $updateAllTypes;
+
+    /**
      * @var int
      */
     private $numberOfReplicas;
@@ -29,12 +34,14 @@ class ApplyMigrationPayload extends MigrationPayload
      *
      * @param string $configurationPath
      * @param int    $batchSize
+     * @param bool   $updateAllTypes
      */
-    public function __construct($configurationPath, $batchSize)
+    public function __construct($configurationPath, $batchSize, $updateAllTypes = false)
     {
         parent::__construct($configurationPath);
 
-        $this->batchSize = $batchSize;
+        $this->batchSize      = $batchSize;
+        $this->updateAllTypes = $updateAllTypes;
     }
 
     /**
@@ -58,7 +65,13 @@ class ApplyMigrationPayload extends MigrationPayload
      */
     public function getTargetConfiguration()
     {
-        return include $this->getTargetVersionPath();
+        $config = include $this->getTargetVersionPath();
+
+        if ($this->updateAllTypes) {
+            $config['update_all_types'] = true;
+        }
+
+        return $config;
     }
 
     /**


### PR DESCRIPTION
Add an option to append `update_all_types` to the index configuration. 

We don't aways need this option, but it allow cascading update for field mapping.

From the [doc](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/indices-put-mapping.html)

> Fields in the same index with the same name in two different types must have the same mapping, as they are backed by the same field internally. Trying to update a mapping parameter for a field which exists in more than one type will throw an exception, unless you specify the update_all_types parameter, in which case it will update that parameter across all fields with the same name in the same index.

```
{
   "error":{
      "root_cause":[
         {
            "type":"illegal_argument_exception",
            "reason":"Mapper for [title] conflicts with existing mapping in other types:\n[mapper [title] is used by multi  
  ple types. Set update_all_types to true to update [search_analyzer] across all types., mapper [title] is used by multiple types. Set update_all_types to true to update [se  
  arch_quote_analyzer] across all types.]"
         }
      ],
      "type":"illegal_argument_exception",
      "reason":"Mapper for [title] conflicts with existing mapping in other types:\n[mapper [title  
  ] is used by multiple types. Set update_all_types to true to update [search_analyzer] across all types., mapper [title] is used by multiple types. Set update_all_types to   
  true to update [search_quote_analyzer] across all types.]"
   },
   "status":400
}
```