### PR TITLE
Fix issue with empty function_score query

### DIFF
--- a/src/Search/Query/Compound/FunctionScoreQuery.php
+++ b/src/Search/Query/Compound/FunctionScoreQuery.php
@@ -59,7 +59,7 @@ class FunctionScoreQuery extends AbstractQuery
             if (!empty($queryArray)) {
                 $array['query'] = $queryArray;
             } else {
-                $array['query'] = ['match_all' => []];
+                $array['query'] = ['match_all' => new \stdClass()];
             }
         }
 

--- a/tests/Search/Query/Compound/FunctionScoreQueryTest.php
+++ b/tests/Search/Query/Compound/FunctionScoreQueryTest.php
@@ -59,11 +59,11 @@ class FunctionScoreQueryTest extends AbstractQueryTestCase
                         ]
                     ]
                 ],
-                'weight'     => 34.12,
-                'boost'      => 5.1,
-                'max_boost'  => 14.3,
+                'weight' => 34.12,
+                'boost' => 5.1,
+                'max_boost' => 14.3,
                 'boost_mode' => 'multiply',
-                'min_score'  => 1,
+                'min_score' => 1,
             ]
         ];
 
@@ -93,6 +93,23 @@ class FunctionScoreQueryTest extends AbstractQueryTestCase
                             ],
                         ],
                     ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedArray, $functionScoreQuery->toArray());
+    }
+
+    public function testEmptyQuery()
+    {
+        $functionScoreQuery = new FunctionScoreQuery();
+
+        $functionScoreQuery->setQuery(new BoolQuery());
+
+        $expectedArray = [
+            'function_score' => [
+                'query' => [
+                    'match_all' => new \stdClass()
                 ],
             ],
         ];


### PR DESCRIPTION
*  "match_all": [] should be "match_all": {}. Otherwise ES will throws: parsing_exception: [match_all] query malformed, no start_object after query name

