### PR TITLE
Change IndexCommand so an AbstractMultiIndexCommand can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ class IndexPersonsCommand extends IndexCommand
 Now, run `php artisan app:index:persons` to index the data. You can now create additional commands for your other data 
 types that need to be indexed.
 
+In addition to `IndexCommand` there is an `AbstractMultiIndexCommand` that can be used if you need to index the same 
+data into multiple indices. This can be useful if you're migrating Elasticsearch 5.x indices to Elasticsearch 6.x, 
+which doesn't support indices with multiple different document types.
+
 #### Indexing single items
 
 The console commands are useful when you want to index all items of a particular type, e.g. all persons in your 

--- a/src/Console/AbstractMultiIndexCommand.php
+++ b/src/Console/AbstractMultiIndexCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Nord\Lumen\Elasticsearch\Console;
+
+abstract class AbstractMultiIndexCommand extends IndexCommand
+{
+
+    /**
+     * @return string[] the index names into which the command should index the data
+     */
+    abstract public function getIndices(): array;
+
+    /**
+     * @inheritDoc
+     */
+    public function getIndex()
+    {
+        throw new \RuntimeException('This method should be not be used with ' . __CLASS__);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle()
+    {
+        foreach ($this->getIndices() as $index) {
+            $this->indexData($index);
+        }
+    }
+}

--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -53,21 +53,29 @@ abstract class IndexCommand extends AbstractCommand
      */
     public function handle()
     {
-        $this->info(sprintf('Indexing data of type "%s" into "%s"', $this->getType(), $this->getIndex()));
+        $this->indexData($this->getIndex());
+    }
+
+    /**
+     * @param string $indexName
+     */
+    protected function indexData(string $indexName): void
+    {
+        $this->info(sprintf('Indexing data of type "%s" into "%s"', $this->getType(), $indexName));
 
         $data = $this->getData();
 
         $bar = $this->output->createProgressBar($this->getCount());
         $bar->setRedrawFrequency($this->getProgressBarRedrawFrequency());
 
-        $bulkQuery = new BulkQuery($this->getBulkSize());
+        $bulkQuery              = new BulkQuery($this->getBulkSize());
         $bulkResponseAggregator = new BulkResponseAggregator();
 
         foreach ($data as $item) {
             $action = new BulkAction();
 
             $meta = [
-                '_index' => $this->getIndex(),
+                '_index' => $indexName,
                 '_type'  => $this->getType(),
                 '_id'    => $this->getItemId($item),
             ];
@@ -107,8 +115,6 @@ abstract class IndexCommand extends AbstractCommand
         }
 
         $this->info("\nDone!");
-
-        return 0;
     }
 
     /**


### PR DESCRIPTION
MultiIndexCommand can be used to index the same entity into multiple indices, useful for migrating data from multi-document-type indices to single-document indices.