### PR TITLE
Add support for optional index prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,18 @@ command. If the option is omitted, the default value of 1000 is used.
 There is a console command (`elastic:index:settings:update`) that you can use to update certain dynamic index settings 
 such as the refresh interval or the number of replicas. Simply register it in your console kernel to start using it. 
 
+## Using index prefixes
+
+This library supports specifying a prefix for index names, similarly to how many frameworks support cache prefixes in 
+order to allow multiple applications to share the same cache. This means you can use a single Elasticsearch cluster 
+for multiple projects (or for example a shared one for the "dev" and "staging" environment).
+
+The prefix used is specified by the `ELASTICSEARCH_INDEX_PREFIX` environment variable. If you have an index named 
+`content` and you specify `foo` as a prefix, the index will be named `foo_content`.
+
+Prefixing is supported for index migrations too, in which case the both the indices and the aliases created are 
+prefixed.
+
 ## Pagerfanta integration
 
 There is a Pagerfanta adapter included for easy pagination. However, it is optional, so if you intend to use it you 

--- a/src/Console/ApplyMigrationCommand.php
+++ b/src/Console/ApplyMigrationCommand.php
@@ -4,6 +4,7 @@ namespace Nord\Lumen\Elasticsearch\Console;
 
 use League\Pipeline\Pipeline;
 use Nord\Lumen\Elasticsearch\Exceptions\IndexExistsException;
+use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
 use Nord\Lumen\Elasticsearch\Pipelines\Payloads\ApplyMigrationPayload;
 use Nord\Lumen\Elasticsearch\Pipelines\Stages\CheckIndexExistsStage;
 use Nord\Lumen\Elasticsearch\Pipelines\Stages\CreateIndexStage;
@@ -58,8 +59,8 @@ class ApplyMigrationCommand extends AbstractCommand
         try {
             $pipeline->process($payload);
 
-            $this->output->writeln(sprintf('Migrated %s to %s', $payload->getIndexName(),
-                $payload->getTargetVersionName()));
+            $this->output->writeln(sprintf('Migrated %s to %s', $payload->getPrefixedIndexName(),
+                $payload->getPrefixedTargetVersionName()));
         } catch (IndexExistsException $e) {
             $this->output->writeln('No migration required');
         }

--- a/src/Console/CreateCommand.php
+++ b/src/Console/CreateCommand.php
@@ -1,5 +1,7 @@
 <?php namespace Nord\Lumen\Elasticsearch\Console;
 
+use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
+
 class CreateCommand extends AbstractCommand
 {
 
@@ -33,8 +35,9 @@ class CreateCommand extends AbstractCommand
         }
 
         $params = require($filePath);
+        $params = IndexNamePrefixer::getPrefixedIndexParameters($params);
 
-        $this->info('Creating index ...');
+        $this->info(sprintf("Creating index '%s' ...", $params['index']));
 
         $this->elasticsearchService->indices()->create($params);
 

--- a/src/Console/CreateMigrationCommand.php
+++ b/src/Console/CreateMigrationCommand.php
@@ -44,6 +44,6 @@ class CreateMigrationCommand extends Command
         $payload = new CreateMigrationPayload($configurationPath);
         $pipeline->process($payload);
 
-        $this->output->writeln('Created ' . $payload->getVersionName());
+        $this->output->writeln('Created ' . $payload->getIndexVersionName());
     }
 }

--- a/src/Console/DeleteCommand.php
+++ b/src/Console/DeleteCommand.php
@@ -1,5 +1,7 @@
 <?php namespace Nord\Lumen\Elasticsearch\Console;
 
+use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
+
 class DeleteCommand extends AbstractCommand
 {
 
@@ -22,9 +24,9 @@ class DeleteCommand extends AbstractCommand
      */
     public function handle()
     {
-        $index = (string)$this->argument('index');
+        $index = IndexNamePrefixer::getPrefixedIndexName((string)$this->argument('index'));
 
-        $this->info('Deleting index ...');
+        $this->info(sprintf("Deleting index '%s' ...", $index));
 
         $this->elasticsearchService->indices()->delete(['index' => $index]);
 

--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -3,6 +3,7 @@
 use Nord\Lumen\Elasticsearch\Documents\Bulk\BulkAction;
 use Nord\Lumen\Elasticsearch\Documents\Bulk\BulkQuery;
 use Nord\Lumen\Elasticsearch\Documents\Bulk\BulkResponseAggregator;
+use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
 
 abstract class IndexCommand extends AbstractCommand
 {
@@ -61,6 +62,8 @@ abstract class IndexCommand extends AbstractCommand
      */
     protected function indexData(string $indexName): void
     {
+        $indexName = IndexNamePrefixer::getPrefixedIndexName($indexName);
+        
         $this->info(sprintf('Indexing data of type "%s" into "%s"', $this->getType(), $indexName));
 
         $data = $this->getData();

--- a/src/Console/UpdateIndexSettingsCommand.php
+++ b/src/Console/UpdateIndexSettingsCommand.php
@@ -4,6 +4,7 @@ namespace Nord\Lumen\Elasticsearch\Console;
 
 use Illuminate\Console\Command;
 use Nord\Lumen\Elasticsearch\Contracts\ElasticsearchServiceContract;
+use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
 
 /**
  * Class SetIndexSettingsCommand
@@ -44,7 +45,7 @@ class UpdateIndexSettingsCommand extends Command
 
     public function handle(): void
     {
-        $index           = $this->input->getArgument('index');
+        $index           = IndexNamePrefixer::getPrefixedIndexName($this->input->getArgument('index'));
         $numReplicas     = $this->input->getOption('numReplicas');
         $refreshInterval = $this->input->getOption('refreshInterval');
 

--- a/src/ElasticsearchService.php
+++ b/src/ElasticsearchService.php
@@ -13,7 +13,6 @@ class ElasticsearchService implements ElasticsearchServiceContract
      */
     private $client;
 
-
     /**
      * ElasticsearchService constructor.
      *
@@ -24,24 +23,25 @@ class ElasticsearchService implements ElasticsearchServiceContract
         $this->client = $client;
     }
 
-
     /**
      * @inheritdoc
      */
     public function search(array $params = [])
     {
+        $params = IndexNamePrefixer::getPrefixedIndexParameters($params);
+
         return $this->client->search($params);
     }
-
 
     /**
      * @inheritdoc
      */
     public function index(array $params = [])
     {
+        $params = IndexNamePrefixer::getPrefixedIndexParameters($params);
+
         return $this->client->index($params);
     }
-
 
     /**
      * @inheritdoc
@@ -51,42 +51,45 @@ class ElasticsearchService implements ElasticsearchServiceContract
         return $this->client->reindex($params);
     }
 
-
     /**
      * @inheritdoc
      */
     public function updateByQuery(array $params = [])
     {
+        $params = IndexNamePrefixer::getPrefixedIndexParameters($params);
+
         return $this->client->updateByQuery($params);
     }
-
 
     /**
      * @inheritdoc
      */
     public function bulk(array $params = [])
     {
+        $params = IndexNamePrefixer::getPrefixedIndexParameters($params);
+
         return $this->client->bulk($params);
     }
-
 
     /**
      * @inheritdoc
      */
     public function delete(array $params = [])
     {
+        $params = IndexNamePrefixer::getPrefixedIndexParameters($params);
+
         return $this->client->delete($params);
     }
-
 
     /**
      * @inheritdoc
      */
     public function deleteByQuery(array $params = [])
     {
+        $params = IndexNamePrefixer::getPrefixedIndexParameters($params);
+
         return $this->client->deleteByQuery($params);
     }
-
 
     /**
      * @inheritdoc
@@ -96,24 +99,25 @@ class ElasticsearchService implements ElasticsearchServiceContract
         return $this->client->tasks();
     }
 
-
     /**
      * @inheritdoc
      */
     public function create(array $params = [])
     {
+        $params = IndexNamePrefixer::getPrefixedIndexParameters($params);
+
         return $this->client->create($params);
     }
-
 
     /**
      * @inheritdoc
      */
     public function exists(array $params = [])
     {
+        $params = IndexNamePrefixer::getPrefixedIndexParameters($params);
+
         return $this->client->exists($params);
     }
-
 
     /**
      * @inheritdoc
@@ -123,7 +127,6 @@ class ElasticsearchService implements ElasticsearchServiceContract
         return $this->client->indices();
     }
 
-
     /**
      * @inheritdoc
      */
@@ -131,7 +134,6 @@ class ElasticsearchService implements ElasticsearchServiceContract
     {
         return new Search();
     }
-
 
     /**
      * @inheritdoc
@@ -146,8 +148,10 @@ class ElasticsearchService implements ElasticsearchServiceContract
      */
     public function execute(Search $search)
     {
+        $index = IndexNamePrefixer::getPrefixedIndexName($search->getIndex());
+
         return $this->search([
-            'index' => $search->getIndex(),
+            'index' => $index,
             'type'  => $search->getType(),
             'body'  => $search->buildBody(),
         ]);
@@ -158,8 +162,10 @@ class ElasticsearchService implements ElasticsearchServiceContract
      */
     public function count(Search $search): int
     {
+        $index = IndexNamePrefixer::getPrefixedIndexName($search->getIndex());
+
         return $this->client->count([
-            'index' => $search->getIndex(),
+            'index' => $index,
             'type'  => $search->getType(),
             'body'  => $search->buildBody(),
         ])['count'];

--- a/src/IndexNamePrefixer.php
+++ b/src/IndexNamePrefixer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Nord\Lumen\Elasticsearch;
+
+class IndexNamePrefixer
+{
+    public static function getPrefixedIndexName(string $indexName): string
+    {
+        $prefix = \getenv('ELASTICSEARCH_INDEX_PREFIX');
+
+        if ($prefix) {
+            return \sprintf('%s_%s', $prefix, $indexName);
+        }
+
+        return $indexName;
+    }
+
+    public static function getPrefixedIndexParameters(array $parameters): array
+    {
+        if (isset($parameters['index'])) {
+            $parameters['index'] = self::getPrefixedIndexName($parameters['index']);
+        }
+
+        return $parameters;
+    }
+}

--- a/src/Pipelines/Payloads/ApplyMigrationPayload.php
+++ b/src/Pipelines/Payloads/ApplyMigrationPayload.php
@@ -2,6 +2,8 @@
 
 namespace Nord\Lumen\Elasticsearch\Pipelines\Payloads;
 
+use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
+
 /**
  * Class ApplyMigrationPayload
  * @package Nord\Lumen\Elasticsearch\Pipelines\Payloads
@@ -75,11 +77,27 @@ class ApplyMigrationPayload extends MigrationPayload
     }
 
     /**
+     * @return array
+     */
+    public function getPrefixedTargetConfiguration(): array
+    {
+        return IndexNamePrefixer::getPrefixedIndexParameters($this->getTargetConfiguration());
+    }
+
+    /**
      * @return string
      */
     public function getTargetVersionName()
     {
         return $this->getTargetConfiguration()['index'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrefixedTargetVersionName(): string
+    {
+        return IndexNamePrefixer::getPrefixedIndexName($this->getTargetVersionName());
     }
 
     /**

--- a/src/Pipelines/Payloads/MigrationPayload.php
+++ b/src/Pipelines/Payloads/MigrationPayload.php
@@ -2,6 +2,8 @@
 
 namespace Nord\Lumen\Elasticsearch\Pipelines\Payloads;
 
+use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
+
 /**
  * Class MigrationPayload
  * @package Nord\Lumen\Elasticsearch\Pipelines\Payloads
@@ -54,6 +56,14 @@ abstract class MigrationPayload
     public function getIndexName()
     {
         return $this->getConfiguration()['index'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrefixedIndexName(): string
+    {
+        return IndexNamePrefixer::getPrefixedIndexName($this->getIndexName());
     }
 
     /**

--- a/src/Pipelines/Stages/CheckIndexExistsStage.php
+++ b/src/Pipelines/Stages/CheckIndexExistsStage.php
@@ -31,12 +31,13 @@ class CheckIndexExistsStage implements StageInterface
 
     /**
      * @inheritDoc
+     *
+     * @throws IndexExistsException
      */
     public function __invoke($payload)
     {
         /** @var ApplyMigrationPayload $payload */
-
-        $index    = $payload->getTargetVersionName();
+        $index    = $payload->getPrefixedTargetVersionName();
         $response = $this->elasticsearchService->indices()->exists(['index' => $index]);
 
         if ($response) {

--- a/src/Pipelines/Stages/CreateIndexStage.php
+++ b/src/Pipelines/Stages/CreateIndexStage.php
@@ -34,8 +34,9 @@ class CreateIndexStage implements StageInterface
     public function __invoke($payload)
     {
         /** @var ApplyMigrationPayload $payload */
-        // Create the new index
-        $this->elasticsearchService->indices()->create($payload->getTargetConfiguration());
+        $params = $payload->getPrefixedTargetConfiguration();
+
+        $this->elasticsearchService->indices()->create($params);
 
         return $payload;
     }

--- a/src/Pipelines/Stages/StoreIndexSettingsStage.php
+++ b/src/Pipelines/Stages/StoreIndexSettingsStage.php
@@ -34,13 +34,12 @@ class StoreIndexSettingsStage implements StageInterface
     public function __invoke($payload)
     {
         /** @var ApplyMigrationPayload $payload */
-
         // Store the current number_of_replicas setting value in the payload
-        $settings = $this->elasticsearchService->indices()->getSettings([
-            'index' => $payload->getTargetVersionName(),
-        ]);
+        $index = $payload->getPrefixedTargetVersionName();
 
-        $indexSettings = $settings[$payload->getTargetVersionName()]['settings']['index'];
+        $settings = $this->elasticsearchService->indices()->getSettings(['index' => $index]);
+
+        $indexSettings = $settings[$index]['settings']['index'];
         $payload->setNumberOfReplicas($indexSettings['number_of_replicas']);
 
         return $payload;

--- a/src/Pipelines/Stages/UpdateIndexAliasStage.php
+++ b/src/Pipelines/Stages/UpdateIndexAliasStage.php
@@ -5,6 +5,7 @@ namespace Nord\Lumen\Elasticsearch\Pipelines\Stages;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use League\Pipeline\StageInterface;
 use Nord\Lumen\Elasticsearch\Contracts\ElasticsearchServiceContract;
+use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
 use Nord\Lumen\Elasticsearch\Pipelines\Payloads\ApplyMigrationPayload;
 
 /**
@@ -37,7 +38,7 @@ class UpdateIndexAliasStage implements StageInterface
         /** @var ApplyMigrationPayload $payload */
 
         $indices         = $this->elasticsearchService->indices();
-        $alias           = $payload->getIndexName();
+        $alias           = $payload->getPrefixedIndexName();
         $orphanedIndices = [];
 
         // If we already have an alias in place we store the indices it points to right now
@@ -56,7 +57,7 @@ class UpdateIndexAliasStage implements StageInterface
 
         // Revert temporary index settings
         $indices->putSettings([
-            'index' => $payload->getTargetVersionName(),
+            'index' => $payload->getPrefixedTargetVersionName(),
             'body'  => [
                 'refresh_interval'   => '1s',
                 'number_of_replicas' => $payload->getNumberOfReplicas(),
@@ -69,7 +70,7 @@ class UpdateIndexAliasStage implements StageInterface
                 'actions' => [
                     [
                         'add' => [
-                            'index' => $payload->getTargetVersionName(),
+                            'index' => $payload->getPrefixedTargetVersionName(),
                             'alias' => $alias,
                         ],
                     ],
@@ -79,7 +80,9 @@ class UpdateIndexAliasStage implements StageInterface
 
         // Remove orphaned indices
         foreach ($orphanedIndices as $orphanedIndex) {
-            $indices->delete(['index' => $orphanedIndex]);
+            $prefixedOrphanedIndex = IndexNamePrefixer::getPrefixedIndexName($orphanedIndex);
+            
+            $indices->delete(['index' => $prefixedOrphanedIndex]);
         }
 
         return $payload;

--- a/src/Pipelines/Stages/UpdateIndexAliasStage.php
+++ b/src/Pipelines/Stages/UpdateIndexAliasStage.php
@@ -5,7 +5,6 @@ namespace Nord\Lumen\Elasticsearch\Pipelines\Stages;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use League\Pipeline\StageInterface;
 use Nord\Lumen\Elasticsearch\Contracts\ElasticsearchServiceContract;
-use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
 use Nord\Lumen\Elasticsearch\Pipelines\Payloads\ApplyMigrationPayload;
 
 /**
@@ -80,9 +79,7 @@ class UpdateIndexAliasStage implements StageInterface
 
         // Remove orphaned indices
         foreach ($orphanedIndices as $orphanedIndex) {
-            $prefixedOrphanedIndex = IndexNamePrefixer::getPrefixedIndexName($orphanedIndex);
-            
-            $indices->delete(['index' => $prefixedOrphanedIndex]);
+            $indices->delete(['index' => $orphanedIndex]);
         }
 
         return $payload;

--- a/tests/IndexNamePrefixerTest.php
+++ b/tests/IndexNamePrefixerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Nord\Lumen\Elasticsearch\Tests;
+
+use Nord\Lumen\Elasticsearch\IndexNamePrefixer;
+
+class IndexNamePrefixerTest extends TestCase
+{
+    public function testNoPrefixDefined(): void
+    {
+        putenv('ELASTICSEARCH_INDEX_PREFIX=');
+
+        $this->assertEquals('foo', IndexNamePrefixer::getPrefixedIndexName('foo'));
+        $this->assertEquals(['index' => 'foo'], IndexNamePrefixer::getPrefixedIndexParameters(['index' => 'foo']));
+    }
+
+    public function testPrefixDefined(): void
+    {
+        putenv('ELASTICSEARCH_INDEX_PREFIX=dev');
+
+        $this->assertEquals('dev_foo', IndexNamePrefixer::getPrefixedIndexName('foo'));
+        $this->assertEquals(['index' => 'dev_foo'], IndexNamePrefixer::getPrefixedIndexParameters(['index' => 'foo']));
+    }
+}

--- a/tests/Pipelines/Stages/UpdateIndexAliasStageTest.php
+++ b/tests/Pipelines/Stages/UpdateIndexAliasStageTest.php
@@ -63,6 +63,54 @@ class UpdateIndexAliasStageTest extends TestCase
     }
 
     /**
+     * Tests that the alias gets updated and orphaned indices get deleted
+     */
+    public function testNormalOperationWithPrefix()
+    {
+        putenv('ELASTICSEARCH_INDEX_PREFIX=test');
+        
+        /** @var IndicesNamespace|\PHPUnit_Framework_MockObject_MockObject $indices */
+        $indices = $this->getMockBuilder(IndicesNamespace::class)
+                        ->disableOriginalConstructor()
+                        ->setMethods(['getAlias', 'updateAliases', 'delete', 'putSettings'])
+                        ->getMock();
+
+        // Pretend there's an alias pointing at the index "content_3"
+        $indices->expects($this->once())
+                ->method('getAlias')
+                ->with(['name' => 'test_content'])
+                ->willReturn(['test_content_3' => 'foo']);
+
+        // Expect settings to me updated
+        $indices->expects($this->once())
+                ->method('putSettings');
+
+        // Expect the alias to get updated
+        $indices->expects($this->once())
+                ->method('updateAliases');
+
+        // Expect "content_3" to be deleted
+        $indices->expects($this->once())
+                ->method('delete')
+                ->with(['index' => 'test_content_3']);
+
+        /** @var ElasticsearchServiceContract|\PHPUnit_Framework_MockObject_MockObject $service */
+        $service = $this->getMockBuilder(ElasticsearchServiceContract::class)
+                        ->setMethods(['indices'])
+                        ->getMockForAbstractClass();
+
+        $service->expects($this->once())
+                ->method('indices')
+                ->willReturn($indices);
+
+        $stage   = new UpdateIndexAliasStage($service);
+        $payload = new ApplyMigrationPayload($this->getResourcesBasePath() . '/content.php', 100);
+        $payload->setTargetVersionFile('7.php');
+
+        $this->assertInstanceOf(ApplyMigrationPayload::class, $stage($payload));
+    }
+
+    /**
      * Tests that a missing alias is handled correctly when no index exists
      */
     public function testMissingAliasMissingIndex()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,6 +29,14 @@ class TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @inheritDoc
+     */
+    protected function tearDown()
+    {
+        putenv('ELASTICSEARCH_INDEX_PREFIX=');
+    }
+
+    /**
      * @return string
      */
     protected function getResourcesBasePath()


### PR DESCRIPTION
This is useful in multi-tenant environments where a single Elasticsearch cluster is shared
