### PR TITLE
Properly serialize empty BoolQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.8.2] - 2020-01-15
+
+- Fix a regression when serializing empty Bool queries
+
 ## [3.8.1] - 2019-12-18
 
 - Fix a regression in BulkResponseAggregator (introduced in 3.8.0)

--- a/src/Search/Query/Compound/BoolQuery.php
+++ b/src/Search/Query/Compound/BoolQuery.php
@@ -135,6 +135,12 @@ class BoolQuery extends AbstractQuery
             }
         }
 
+        // Empty queries must be serialized as new \stdClass(), otherwise the Elasticsearch PHP SDK will fail when
+        // encoding the query to JSON (see https://github.com/elastic/elasticsearch-php/issues/495)
+        if (empty($array)) {
+            $array = ['bool' => new \stdClass()];
+        }
+
         return $array;
     }
 }

--- a/tests/Search/Query/Compound/BoolQueryTest.php
+++ b/tests/Search/Query/Compound/BoolQueryTest.php
@@ -21,7 +21,7 @@ class BoolQueryTest extends AbstractQueryTestCase
     public function testToArray()
     {
         $query = new BoolQuery();
-        
+
         $query->addMust(new TermQuery('field1', 'value1'));
         $query->addFilter(new TermQuery('field2', 'value2'));
         $query->addMustNot((new RangeQuery())->setField('field3')->setGreaterThanOrEquals(1)->setLessThanOrEquals(2));
@@ -62,6 +62,13 @@ class BoolQueryTest extends AbstractQueryTestCase
         ];
 
         $this->assertEquals($expectedArray, $query->toArray());
+
+        // Test empty query
+        $query = new BoolQuery();
+
+        $this->assertEquals([
+            'bool' => new \stdClass(),
+        ], $query->toArray());
     }
 
     /**


### PR DESCRIPTION
We used to do this in Search.php, but it was changed to check for null instead of an empty string. This breaks clients relying on the previous behavior to work.

AFAICT all other queries that need this special handling already do it, so this should restore the previous behavior.
